### PR TITLE
Bugfix converting options

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -28,7 +28,7 @@ module.exports = class SlashCommandInteraction {
        * @type {Boolean}
        */
 
-      this.isCommand = this.type === "APPLICATION_COMMAND" ? true : false;
+      this.isCommand = this.type === "APPLICATION_COMMAND";
 
       /**
        * Channel the interaction occured in.

--- a/src/structures/SlashCommandHandler.js
+++ b/src/structures/SlashCommandHandler.js
@@ -115,7 +115,7 @@ module.exports = class SlashCommandHandler {
         return {
           name: x.name.toLowerCase(),
           description: x.description,
-          options: ConvertOptions(x),
+          options: ConvertOptions(x.options),
         };
       });
 

--- a/src/utils/ConvertOptions.js
+++ b/src/utils/ConvertOptions.js
@@ -78,8 +78,8 @@ module.exports.CommandInteractionOptions = (options, client, guild) => {
           argToSet.role = new Role(this.client, optionsRole, this.guild);
         }
       }
+      returnCollection.set(argToSet.name, argToSet);
     }
-    returnCollection.set(argToSet.name, argToSet);
   };
   return returnCollection;
 };


### PR DESCRIPTION
Variable 'x' is the entire structure, not just the options. ConvertOptions should use the 'options' field inside 'x' instead for its conversion.