### PR TITLE
Bugfix of ephemeral option/missing options

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -229,7 +229,7 @@ module.exports = class SlashCommandInteraction {
       files,
     });
 
-    this.epehemeral = options["ephemeral"] ? true : false;
+    this.ephemeral = !!options?.ephemeral;
 
     this.replied = true;
   }

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -229,7 +229,7 @@ module.exports = class SlashCommandInteraction {
       files,
     });
 
-    this.ephemeral = !!options?.ephemeral;
+    this.ephemeral = options ? !!options.ephemeral : false;
 
     this.replied = true;
   }
@@ -243,7 +243,7 @@ module.exports = class SlashCommandInteraction {
     if (this.deferred || this.replied)
       throw new Error("Interaction already replied.");
 
-    this.ephemeral = ephemeral ? true : false;
+    this.ephemeral = options ? !!options.ephemeral : false;
     await this.client.api.interactions(this.id, this.token).callback.post({
       data: {
         type: 5,


### PR DESCRIPTION
• Typo: 'epehemeral' → 'ephemeral', means 'ephemeral' is always false
• Made statement account for undefined options, so you don't get error "ephemeral" being undefined if you omit options
• Simplified statement (supported NodeJS ^14.0.0, see other comment for lower version support)